### PR TITLE
Delete scheduled tasks after execution

### DIFF
--- a/update/elevated-template.ps1
+++ b/update/elevated-template.ps1
@@ -101,5 +101,9 @@ $result = $t.LastTaskResult
 if (Test-Path $log) {
     Remove-Item $log -Force -ErrorAction SilentlyContinue | Out-Null
 }
+
+# delete scheduled task
+$f.DeleteTask("\$name", 0)
+
 [System.Runtime.Interopservices.Marshal]::ReleaseComObject($s) | Out-Null
 exit $result


### PR DESCRIPTION
## Problem
The plugin leaves two scheduled tasks behin starting with `packer-windows-update` that might pose a security risk.
This was also mentioned in issue https://github.com/rgl/packer-plugin-windows-update/issues/106.

## Question
Could this be a suitable fix? Is does not look like the tasks are re-used anywhere so why not delete them as part of the execution. Unfortunately, I don't have a development environment set up for plugin development to test it myself nor do I know Go.
@rgl could you maybe have a quick look at this? Thank you in advance.