### PR TITLE
Handle different exit code on windows 2012

### DIFF
--- a/update/provisioner.go
+++ b/update/provisioner.go
@@ -216,6 +216,9 @@ func (p *Provisioner) update(ctx context.Context, ui packer.Ui, comm packer.Comm
 		case 101:
 			restartPending = true
 			return nil
+		case 2147942501: //windows 2012
+			restartPending = true
+			return nil
 		default:
 			return fmt.Errorf("Windows update script exited with non-zero exit status: %d", exitStatus)
 		}
@@ -277,6 +280,8 @@ func (p *Provisioner) restart(ctx context.Context, ui packer.Ui, comm packer.Com
 			case exitStatus == 0:
 				restartPending = false
 			case exitStatus == 101:
+				restartPending = true
+			case exitStatus == 2147942501: //windows 2012
 				restartPending = true
 			default:
 				return fmt.Errorf("Machine not yet available (exit status %d)", exitStatus)


### PR DESCRIPTION
On Server 2012, scheduled task does not exit 101, rather exits 2147942501 when reboot required

On many of our VM builds, this works fine, but on Server 2012 in particular this appears to get stuck, printing Waiting for the Windows Modules Installer to exit... to the console and logging Retryable error: Windows update script exited with non-zero exit status: 2147942501 to the log.

This PR adds the exit code in the 2 spots it's required, so that it can detect the reboot required state.

Fixes https://github.com/rgl/packer-plugin-windows-update/issues/130

