### PR TITLE
Add condition to check for duplicate queued updates

### DIFF
--- a/update/windows-update.ps1
+++ b/update/windows-update.ps1
@@ -202,7 +202,7 @@ for ($i = 0; $i -lt $searchResult.Updates.Count; ++$i) {
     }
 
     if (($updatesToInstall | Select-Object -ExpandProperty Title) -contains $updateTitle) {
-        Write-Output "Warning, The update '$updateTitle' has already been found, cannot add the same update again! Skipping."
+        Write-Output "Warning, Skipping queueing the duplicated titled update '$updateTitle'."
         continue
     }
 

--- a/update/windows-update.ps1
+++ b/update/windows-update.ps1
@@ -201,6 +201,11 @@ for ($i = 0; $i -lt $searchResult.Updates.Count; ++$i) {
         Write-Output "Warning The update '$updateTitle' has the CanRequestUserInput flag set (if the install hangs, you might need to exclude it with the filter 'exclude:`$_.InstallationBehavior.CanRequestUserInput' or 'exclude:`$_.Title -like '*$updateTitle*'')"
     }
 
+    if (($updatesToInstall | Select-Object -ExpandProperty Title) -contains $updateTitle) {
+        Write-Output "Warning, The update '$updateTitle' has already been found, cannot add the same update again! Skipping."
+        continue
+    }
+
     Write-Output "Found $updateSummary"
 
     $update.AcceptEula() | Out-Null


### PR DESCRIPTION
This commit helps the occurence of duplicate Windows Update's getting queued and causing Windows Update to refuse to do windows update work. We add logic to find and skip duplicate Windows Updates.

Orginal PR
This PR detects when an update is attempted to be installed which equal the same update by its title. We do this by comparing what is currently in the install object, using the update title and skip the update it if we find it already in the object. This stops the HRESULT: 0x80240013 which is, as far as I know, when a duplicate update is attempted to be installed at the same time.

Resolves https://github.com/rgl/packer-plugin-windows-update/issues/131